### PR TITLE
Made the cop dynamic for other methods

### DIFF
--- a/rubocop/jekyll/assert_equal_literal_actual.rb
+++ b/rubocop/jekyll/assert_equal_literal_actual.rb
@@ -101,9 +101,9 @@ module RuboCop
             node.each_child_node.all?(&method(:literal?))
         end
 
-		    def assert_pattern?(method)
-		      EXP_ACT_MSG_PATTERN_METHODS.include?(method)
-		    end
+        def assert_pattern?(method)
+          EXP_ACT_MSG_PATTERN_METHODS.include?(method)
+        end
 
         def line_length_max
           config.for_cop('Metrics/LineLength')['Max'] # Defaults to 80


### PR DESCRIPTION
For all the methods that follow that pattern, this adds a fix.

This also adds in a spacing fix so autocorrect doesnt force another correction by the line-indentation cop.

I am thinking though that the `return "#{replaced_text}, #{optional_param.source}" if optional_param` line might be problematic when we use parameters. I am thinking that we might want to put a placeholder always and replace it with the parameter when appropriate and an empty strring when not. Or some other change.